### PR TITLE
Add github-actions for github-packages publishing & Port to 1.21

### DIFF
--- a/.github/workflows/maven-publish-ghpkg.yml
+++ b/.github/workflows/maven-publish-ghpkg.yml
@@ -1,0 +1,42 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package and Publish to GitHub Packages
+
+run-name: 'Package Publish #${{github.run_number}}'
+
+on:
+  release:
+    types: [published]
+    
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout code       
+      uses: actions/checkout@v4
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'oracle'
+        server-id: 'github-package'
+        cache: 'maven'
+
+    - name: Build with Maven
+      run: mvn --batch-mode package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn --batch-mode deploy
+      env:
+        GITHUB_MAVEN_URL: https://maven.pkg.github.com/${{github.repository}}
+        GITHUB_TOKEN: ${{secrets.PACKAGE_PUBLISH_TOKEN}}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Compiled class file
 *.class
+target/
+dependency-reduced-pom.xml
 
 # Log file
 *.log

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>cat.nyaa</groupId>
     <artifactId>ecore</artifactId>
-    <version>0.3.3</version>
+    <version>0.3.4</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -58,17 +58,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.9.0</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.1-SNAPSHOT</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -126,9 +126,9 @@
 
     <distributionManagement>
         <repository>
-            <id>local-dist</id>
-            <!--suppress UnresolvedMavenProperty -->
-            <url>file://${mavenLocalDistDir}</url>
+            <id>github-package</id>
+            <name>Github Package</name>
+            <url>${env.GITHUB_MAVEN_URL}</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
1. Add github-actions for github-packages publishing
   1. secrets.PACKAGE_PUBLISH_TOKEN  is required for github-packages/maven authorization
   2. maven url: https://maven.pkg.github.com/${{github.repository}}

4. Port to 1.21
   1.  version 0.3.3 -> 0.3.4
   2. update java to jdk21
   3. update spigot api to 1.21-R0.1-SNAPSHOT
   4. update other plugins in order to meet the requirement of jdk21 compiling